### PR TITLE
process.env scoped to .env file in the root directory of the project

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+# Pass in your slack webhook URL https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
+SLACK_WEBHOOK_URL=

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ So you will have all the modules that we are using.
 1. Defined Xray's webook by following [these steps](https://www.jfrog.com/confluence/display/JFROG/Configuring+Xray#ConfiguringXray-ConfiguringWebhooks).
    If you wish to see (even) better tutorial check this [post](https://greenido.wordpress.com/?p=9820).
 
-1. Copy this [project](https://github.com/greenido/jfrog-xray-2-slack-example) and change (in .env file):
+1. Copy this [project](https://github.com/greenido/jfrog-xray-2-slack-example) and change (in .env file placed in the root directory):
 
 ```
 SLACK_WEBHOOK_URL=https://hooks.slack.com/services/specific-string-from-slack/more-chars-from-slack-that-are-unique

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "express": "^4.17.1",
     "body-parser": "^1.19.0",
     "request": "^2.88.2",
-    "https": "^1.0.0"
+    "https": "^1.0.0",
+    "dotenv": "^8.2.0"
   },
   "engines": {
     "node": "12.x"

--- a/routes.js
+++ b/routes.js
@@ -9,6 +9,9 @@
 const fs = require("fs");
 const https = require("https");
 const dotenv = require("dotenv");
+// Loads environment variables from a .env file into process.env
+// console.log("------------------------"+process.env.SLACK_WEBHOOK_URL);
+dotenv.config();
 
 //
 // Main End points of our app
@@ -104,11 +107,6 @@ var routes = function(app) {
  */
 function sendSlackMessage(messageBody) {
   try {
-
-    // Loads environment variables from a .env file into process.env
-    // console.log("------------------------"+process.env.SLACK_WEBHOOK_URL);
-    dotenv.config();
-
     //console.log("=== " + messageBody);
     messageBody = JSON.stringify(messageBody);
   } catch (e) {

--- a/routes.js
+++ b/routes.js
@@ -8,6 +8,7 @@
 //
 const fs = require("fs");
 const https = require("https");
+const dotenv = require("dotenv");
 
 //
 // Main End points of our app
@@ -67,7 +68,7 @@ var routes = function(app) {
             {
               title: "Severity",
               value: payload.issues[0].severity,
-              short: true 
+              short: true
             },
             {
               title: "Created",
@@ -103,6 +104,11 @@ var routes = function(app) {
  */
 function sendSlackMessage(messageBody) {
   try {
+
+    // Loads environment variables from a .env file into process.env
+    // console.log("------------------------"+process.env.SLACK_WEBHOOK_URL);
+    dotenv.config();
+
     //console.log("=== " + messageBody);
     messageBody = JSON.stringify(messageBody);
   } catch (e) {

--- a/routes.js
+++ b/routes.js
@@ -9,7 +9,7 @@
 const fs = require("fs");
 const https = require("https");
 const dotenv = require("dotenv");
-// Loads environment variables from a .env file into process.env
+// Loads environment variables from the .env file into process.env
 // console.log("------------------------"+process.env.SLACK_WEBHOOK_URL);
 dotenv.config();
 


### PR DESCRIPTION
making process.env scoped to .env file in the root directory of the project instead of setting up an environment variable. This would avoid the variable from being "undefined"